### PR TITLE
Highlight all dot-separated property names

### DIFF
--- a/syntax/rhai.tmLanguage.json
+++ b/syntax/rhai.tmLanguage.json
@@ -843,7 +843,7 @@
           }
         },
         {
-          "match": "(?<=(\\.|\\?\\.))\\s*([_a-zA-Z]\\w*)",
+          "match": "(?<=\\.|\\?\\.)\\s*([_a-zA-Z]\\w*)",
           "captures": {
             "1": {
               "name": "variable.other.property.rhai entity.name.property.rhai"


### PR DESCRIPTION
Fixes #7 – only the first segment of a dotted identifier was highlighted.

This fix removes the capturing parentheses inside the look-behind expression `(?<=…)`  in the rule `"variable.other.property.rhai entity.name.property.rhai"`. This colors every segment that follows `.` or `?.` consistently.
